### PR TITLE
Fix static method call

### DIFF
--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2005,7 +2005,6 @@ namespace ApiDoctor.ConsoleApp
         /// <param name="issues">logging</param>
         private static void WriteHttpSnippetsIntoFile(string tempDir, MethodDefinition[] methods, IssueLogger issues)
         {
-            var parser = new HttpParser();
             foreach (var method in methods)
             {
                 HttpRequest request;
@@ -2013,7 +2012,7 @@ namespace ApiDoctor.ConsoleApp
                 try
                 {
                     snippetPrefix = GetSnippetPrefix(method);
-                    request = parser.ParseHttpRequest(method.Request);
+                    request = HttpParser.ParseHttpRequest(method.Request);
                 }
                 catch (Exception e)
                 {
@@ -2102,7 +2101,7 @@ namespace ApiDoctor.ConsoleApp
                                 break;
                             }
                             if (originalFileContents[identifierIndex].Contains("```http") 
-                                && new HttpParser().ParseHttpRequest(method.Request).Method.Equals("GET"))
+                                && HttpParser.ParseHttpRequest(method.Request).Method.Equals("GET"))
                             {
                                 originalFileContents[identifierIndex] = "```msgraph-interactive";
                             }


### PR DESCRIPTION
Unblocking the following failure by using type names instead of instance variables:

https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=33458&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=b1657ed2-8cf9-53e1-bfff-c661b553db41&l=120