### PR TITLE
[Snippet Generation] Add custom metadata support

### DIFF
--- a/ApiDoctor.Console/CommandLineOptions.cs
+++ b/ApiDoctor.Console/CommandLineOptions.cs
@@ -632,5 +632,8 @@ namespace ApiDoctor.ConsoleApp
 
         [Option("lang", HelpText = "The programming languages for snippet generation(comma separated list)", Required = true)]
         public string Languages { get; set; }
+
+        [Option("custom-metadata-path", HelpText = "Path to custom metadata that snippet generation can consume", Required = false)]
+        public string CustomMetadataPath { get; set; }
     }
 }

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -1922,8 +1922,16 @@ namespace ApiDoctor.ConsoleApp
 
             WriteHttpSnippetsIntoFile(snippetsPath, methods, issues);
 
-            GenerateSnippets(options.SnippetGeneratorPath, // executable path
-                "--SnippetsPath", snippetsPath, "--Languages", options.Languages); // args
+            if (string.IsNullOrWhiteSpace(options.CustomMetadataPath))
+            {
+                GenerateSnippets(options.SnippetGeneratorPath, // executable path
+                    "--SnippetsPath", snippetsPath, "--Languages", options.Languages); // args
+            }
+            else
+            {
+                GenerateSnippets(options.SnippetGeneratorPath, // executable path
+                    "--SnippetsPath", snippetsPath, "--Languages", options.Languages, "--CustomMetadataPath", options.CustomMetadataPath); // args
+            }
 
             var languages = options.Languages.Split(',');
             foreach (var method in methods)


### PR DESCRIPTION
Step 2 of the proposed solution in https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/383

- Adds a new command line parameter for custom metadata inputs
- Plumbs that value into the snippet generation tool.

Related
https://github.com/microsoftgraph/microsoft-graph-explorer-api/pull/384
https://github.com/microsoftgraph/msgraph-sdk-raptor/pull/117