### PR TITLE
Bugfix/snippet language casing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": ".NET Core Launch (console)",
+			"type": "coreclr",
+			"request": "launch",
+			"preLaunchTask": "build",
+			"program": "${workspaceFolder}/ApiDoctor.Console/bin/Debug/net5.0/apidoc.dll",
+			"args": [
+				"generate-snippets",
+				"--ignore-warnings",
+				"--path",
+				"/home/codespace/workspace/microsoft-graph-docs",
+				"--snippet-generator-path",
+				"/home/codespace/workspace/microsoft-graph-explorer-api/CodeSnippetsReflection.App/bin/Debug/net5.0/CodeSnippetsReflection.App",
+				"--lang",
+				"Java",
+				"--git-path",
+				"/bin/git"
+			],
+			"cwd": "${workspaceFolder}/ApiDoctor.Console",
+			"console": "internalConsole",
+			"stopAtEntry": false
+		},
+		{
+			"name": ".NET Core Attach",
+			"type": "coreclr",
+			"request": "attach",
+			"processId": "${command:pickProcess}"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/ApiDoctor.Console/ApiDoctor.ConsoleApp.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/ApiDoctor.Console/ApiDoctor.ConsoleApp.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/ApiDoctor.Console/ApiDoctor.ConsoleApp.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2228,6 +2228,8 @@ namespace ApiDoctor.ConsoleApp
 
         }
 
+        private const string graphHostName = "graph.microsoft.com";
+        private const string hostHeaderKey = "Host";
         /// <summary>
         /// Finds the file the request is located and inserts the code snippet into the file.
         /// </summary>
@@ -2239,18 +2241,24 @@ namespace ApiDoctor.ConsoleApp
             //Version 1.1 of HTTP protocol MUST specify the host header
             if (request.HttpVersion.Equals("HTTP/1.1"))
             {
-                if ((request.Headers.Get("Host") == null) || (request.Headers.Get("host") == null))
+                if (!request.Headers.AllKeys.Contains(hostHeaderKey) || string.IsNullOrEmpty(request.Headers[hostHeaderKey]))
                 {
                     try
                     {
                         var testUri = new Uri(request.Url);
                         request.Url = testUri.PathAndQuery;
-                        request.Headers.Add("Host", testUri.Host);
+                        if(request.Headers.AllKeys.Contains(hostHeaderKey))
+                            request.Headers[hostHeaderKey] = testUri.Host;
+                        else
+                            request.Headers.Add(hostHeaderKey, testUri.Host);
                     }
                     catch (UriFormatException)
                     {
                         //cant determine host. Relative url with no host header
-                        request.Headers.Add("Host", "graph.microsoft.com");
+                        if(request.Headers.AllKeys.Contains(hostHeaderKey))
+                            request.Headers[hostHeaderKey] = graphHostName;
+                        else
+                            request.Headers.Add(hostHeaderKey, graphHostName);
                     }
                 }
             }

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -1940,7 +1940,7 @@ namespace ApiDoctor.ConsoleApp
                         continue;
                     }
 
-                    var fileName = $"{snippetPrefix}---{lang}";
+                    var fileName = $"{snippetPrefix}---{lang.ToLowerInvariant()}";
                     var fileFullPath = Path.Combine(snippetsPath, fileName);
                     FancyConsole.WriteLine(FancyConsole.ConsoleSuccessColor, $"Reading {fileFullPath}");
 

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2251,6 +2251,13 @@ namespace ApiDoctor.ConsoleApp
                             request.Headers[hostHeaderKey] = testUri.Host;
                         else
                             request.Headers.Add(hostHeaderKey, testUri.Host);
+                        
+                        if(string.IsNullOrEmpty(request.Headers[hostHeaderKey])) {
+                            if(request.Headers.AllKeys.Contains(hostHeaderKey))
+                                request.Headers[hostHeaderKey] = graphHostName;
+                            else
+                                request.Headers.Add(hostHeaderKey, graphHostName);
+                        }
                     }
                     catch (UriFormatException)
                     {

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2060,8 +2060,11 @@ namespace ApiDoctor.ConsoleApp
                 var fileFullPath = Path.Combine(tempDir, fileName);
                 FancyConsole.WriteLine(FancyConsole.ConsoleSuccessColor, $"Writing {fileFullPath}");
 
-                File.WriteAllText(fileFullPath, request.FullHttpText(true));
+                File.WriteAllText(fileFullPath, ReplaceLFbyCRLF(request.FullHttpText(true)));
             }
+        }
+        private static string ReplaceLFbyCRLF(string original) {
+            return original.Replace("\r\n", "\n").Replace("\n", "\r\n"); // we first replace CRLF by LF and then all LF by CRLF to avoid breaking any CRLF or missing any LF
         }
         /// <summary>
         /// Replaces \ by / to keep output mardown consistent accross generation OSes

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2246,18 +2246,13 @@ namespace ApiDoctor.ConsoleApp
                     try
                     {
                         var testUri = new Uri(request.Url);
-                        request.Url = testUri.PathAndQuery;
+                        request.Url = WebUtility.UrlDecode(testUri.PathAndQuery);
+                        var hostName = string.IsNullOrEmpty(testUri.Host) ? graphHostName : testUri.Host;
+
                         if(request.Headers.AllKeys.Contains(hostHeaderKey))
-                            request.Headers[hostHeaderKey] = testUri.Host;
+                            request.Headers[hostHeaderKey] = hostName;
                         else
-                            request.Headers.Add(hostHeaderKey, testUri.Host);
-                        
-                        if(string.IsNullOrEmpty(request.Headers[hostHeaderKey])) {
-                            if(request.Headers.AllKeys.Contains(hostHeaderKey))
-                                request.Headers[hostHeaderKey] = graphHostName;
-                            else
-                                request.Headers.Add(hostHeaderKey, graphHostName);
-                        }
+                            request.Headers.Add(hostHeaderKey, hostName);
                     }
                     catch (UriFormatException)
                     {

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -1967,12 +1967,13 @@ namespace ApiDoctor.ConsoleApp
         /// <param name="args">arguments to snippet generator</param>
         private static void GenerateSnippets(string executablePath, params string[] args)
         {
-            var startInfo = new ProcessStartInfo(executablePath, string.Join(" ", args))
-            {
-                RedirectStandardError = true,
-                RedirectStandardOutput = true,
+            using var process = new Process{
+                StartInfo = new ProcessStartInfo(executablePath, string.Join(" ", args))
+                {
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                }
             };
-            using var process = Process.Start(startInfo);
             using var outputWaitHandle = new AutoResetEvent(false);
             using var errorWaitHandle = new AutoResetEvent(false);
             process.OutputDataReceived += (sender, e) => {
@@ -1997,6 +1998,7 @@ namespace ApiDoctor.ConsoleApp
                     FancyConsole.Write(FancyConsole.ConsoleDefaultColor, e.Data);
                 }
             };
+            process.Start();
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
             process.WaitForExit();


### PR DESCRIPTION
- fixes an issue where http snippet file name casing would be different with explorer api, causing a mismatch on unix file system
- fixes an issue where an empty hostname would be serialized, causing deserialization to crash
- fixes an issue where the LF would be inconsistent with HTTP spec because of OS, causing deserialization to crash
- fixes an issue where URL manipulation would include an additional encoding on certain platforms
- adds vscode debugging files